### PR TITLE
chore(MegaLinter): Remove no longer needed ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,10 +4,6 @@ report/
 # mypy
 .mypy_cache
 
-# npm
-node_modules
-package-lock.json
-
 # Poetry
 .venv
 


### PR DESCRIPTION
`node_modules` and `package-lock.json` were previously created by MegaLinter since we had configured it to explicitly install `eslint-plugin-jsonc`. This ineffective workaround was since removed in 2ae814a68c6965b3398b5feecde88bc1b9215610.