### PR TITLE
docs(CONTRIBUTING): Correct pre-commit command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,9 +44,11 @@
   ```sh
   pre-commit install \
     --hook-type commit-msg \
+    --hook-type post-checkout \
     --hook-type pre-commit \
     --hook-type pre-merge-commit \
-    --hook-type pre-push
+    --hook-type pre-push \
+    --install-hooks
   ```
 
 ## Expectations


### PR DESCRIPTION
The post-checkout hooks were not installed. Also, recommend installing all hooks synchronously rather than waiting until the first time they are run. This way the hook environments can be setup while developers finish reading the documentation.