### PR TITLE
ci(pre-commit): Add check-useless-excludes hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -154,6 +154,11 @@ repos:
 
   # Check for issues.
 
+  ## Pre-commit
+  - repo: meta
+    hooks:
+      - id: check-useless-excludes
+
   ## Python
   - repo: https://github.com/PyCQA/pydocstyle
     rev: 6.1.1


### PR DESCRIPTION
Ensure that every exclude pattern for our pre-commit hooks matches at least one file in this repository.