### PR TITLE
refactor(SlackNotification): Simplify some Python

### DIFF
--- a/src/pull_request_assignment.py
+++ b/src/pull_request_assignment.py
@@ -29,9 +29,10 @@ class PullRequestAssignment(SlackNotification):
     def get_message(self) -> str:
         """Return a message assigning a pull request."""
         actor = self.get_actor()
-        if actor == self._assignee:
-            assignment = "self-assigned"
-        else:
-            assignment = f"assigned *{self._assignee}* to"
+        assignment = (
+            "self-assigned"
+            if actor == self._assignee
+            else f"assigned *{self._assignee}* to"
+        )
         event_info = self.get_event_info(self._author)
         return f"{actor} {assignment} {event_info}."

--- a/src/reviewers_assignment.py
+++ b/src/reviewers_assignment.py
@@ -30,9 +30,10 @@ class ReviewersAssignment(SlackNotification):
     def get_message(self) -> str:
         """Return a message requesting review of a pull request."""
         actor = self.get_actor()
-        if f"*{actor}*" == self._reviewers:
-            request = "self-requests review"
-        else:
-            request = f"requests review from {self._reviewers}"
+        request = (
+            "self-requests review"
+            if f"*{actor}*" == self._reviewers
+            else f"requests review from {self._reviewers}"
+        )
         event_info = self.get_event_info(self._author)
         return f"{actor} {request} of {event_info}."

--- a/src/workflow_result.py
+++ b/src/workflow_result.py
@@ -39,16 +39,17 @@ class WorkflowResult(SlackNotification):
 
     def _get_workflow_result(self) -> str:
         """Return a single workflow result summarizing the job results."""
-        if len(self._job_results) == 1:
-            return self._job_results[0]
         if all(result == "skipped" for result in self._job_results):
             return "skipped"
         if all(result in ("success", "skipped") for result in self._job_results):
             return "success"
 
         # The workflow was unsuccessful; return the most severe result present.
-        for result in ("failure", "cancelled"):
-            if result in self._job_results:
-                return result
-
-        return " ".join(self._job_results)
+        return next(
+            (
+                result
+                for result in ("failure", "cancelled")
+                if result in self._job_results
+            ),
+            " ".join(self._job_results),
+        )


### PR DESCRIPTION
Use more idiomatic language features, specifically assignment expressions, conditional expressions, and `next`, for clarity. Remove an unnecessary test in `WorkflowResult`. A list of length one is not a special case; ultimately the lone element will be returned regardless.