### PR TITLE
docs(README): Specify specific version in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ because merges will be indistinguishable from direct pushes.
 ```yaml
 - name: Send Slack notification with job status.
   if: always()
-  uses: ScribeMD/slack-templates@0
+  uses: ScribeMD/slack-templates@0.1.1
   with:
     bot-token: ${{ secrets.SLACK_TEMPLATES_BOT_TOKEN }}
     channel-id: ${{ secrets.SLACK_TEMPLATES_CHANNEL_ID }}
@@ -130,7 +130,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Send Slack notification with workflow result.
-        uses: ScribeMD/slack-templates@0
+        uses: ScribeMD/slack-templates@0.1.1
         with:
           bot-token: ${{ secrets.SLACK_TEMPLATES_BOT_TOKEN }}
           channel-id: ${{ secrets.SLACK_TEMPLATES_CHANNEL_ID }}
@@ -153,7 +153,7 @@ jobs:
   shell: bash
 - name: Send Slack notification with custom result.
   if: always() && steps.network.outputs.outage == 'true'
-  uses: ScribeMD/slack-templates@0
+  uses: ScribeMD/slack-templates@0.1.1
   with:
     bot-token: ${{ secrets.SLACK_TEMPLATES_BOT_TOKEN }}
     channel-id: ${{ secrets.SLACK_TEMPLATES_CHANNEL_ID }}
@@ -194,7 +194,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Send Slack notification assigning pull request.
-        uses: ScribeMD/slack-templates@0
+        uses: ScribeMD/slack-templates@0.1.1
         with:
           bot-token: ${{ secrets.SLACK_TEMPLATES_BOT_TOKEN }}
           channel-id: ${{ secrets.SLACK_TEMPLATES_CHANNEL_ID }}
@@ -206,7 +206,7 @@ jobs:
 ```yaml
 - name: Send custom Slack notification.
   if: always()
-  uses: ScribeMD/slack-templates@0
+  uses: ScribeMD/slack-templates@0.1.1
   with:
     bot-token: ${{ secrets.SLACK_TEMPLATES_BOT_TOKEN }}
     channel-id: ${{ secrets.SLACK_TEMPLATES_CHANNEL_ID }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,8 @@ build-backend = "poetry.core.masonry.api"
   [tool.commitizen]
   version = "0.1.1"
   version_files = [
-    "pyproject.toml:version"
+    "pyproject.toml:version",
+    "README.md:slack-templates@"
   ]
 
   [tool.isort]


### PR DESCRIPTION
We do not tag the major version, so users must specify a specific version of the action to use.