### PR TITLE
docs(README): Update version specified in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ because merges will be indistinguishable from direct pushes.
 ```yaml
 - name: Send Slack notification with job status.
   if: always()
-  uses: ScribeMD/slack-templates@0.1.1
+  uses: ScribeMD/slack-templates@0.1.2
   with:
     bot-token: ${{ secrets.SLACK_TEMPLATES_BOT_TOKEN }}
     channel-id: ${{ secrets.SLACK_TEMPLATES_CHANNEL_ID }}
@@ -130,7 +130,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Send Slack notification with workflow result.
-        uses: ScribeMD/slack-templates@0.1.1
+        uses: ScribeMD/slack-templates@0.1.2
         with:
           bot-token: ${{ secrets.SLACK_TEMPLATES_BOT_TOKEN }}
           channel-id: ${{ secrets.SLACK_TEMPLATES_CHANNEL_ID }}
@@ -153,7 +153,7 @@ jobs:
   shell: bash
 - name: Send Slack notification with custom result.
   if: always() && steps.network.outputs.outage == 'true'
-  uses: ScribeMD/slack-templates@0.1.1
+  uses: ScribeMD/slack-templates@0.1.2
   with:
     bot-token: ${{ secrets.SLACK_TEMPLATES_BOT_TOKEN }}
     channel-id: ${{ secrets.SLACK_TEMPLATES_CHANNEL_ID }}
@@ -194,7 +194,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Send Slack notification assigning pull request.
-        uses: ScribeMD/slack-templates@0.1.1
+        uses: ScribeMD/slack-templates@0.1.2
         with:
           bot-token: ${{ secrets.SLACK_TEMPLATES_BOT_TOKEN }}
           channel-id: ${{ secrets.SLACK_TEMPLATES_CHANNEL_ID }}
@@ -206,7 +206,7 @@ jobs:
 ```yaml
 - name: Send custom Slack notification.
   if: always()
-  uses: ScribeMD/slack-templates@0.1.1
+  uses: ScribeMD/slack-templates@0.1.2
   with:
     bot-token: ${{ secrets.SLACK_TEMPLATES_BOT_TOKEN }}
     channel-id: ${{ secrets.SLACK_TEMPLATES_CHANNEL_ID }}


### PR DESCRIPTION
The latest version of `slack-templates` is 0.1.2. Going forward, Commitizen will automatically bump these version numbers.