### PR TITLE
ci(MegaLinter): Specify Markdownlint config file

### DIFF
--- a/.dictionary.txt
+++ b/.dictionary.txt
@@ -1,4 +1,5 @@
 Laven
+Markdownlint
 MegaLinter
 requestee
 slackapi

--- a/.mega-linter.yaml
+++ b/.mega-linter.yaml
@@ -12,6 +12,7 @@ JSON_PRETTIER_FILE_EXTENSIONS:
   - .json
   - .md
 CREDENTIALS_SECRETLINT_ARGUMENTS: --secretlintignore .gitignore
+MARKDOWN_MARKDOWNLINT_CONFIG_FILE: .markdownlint.yaml
 PYTHON_FLAKE8_PRE_COMMANDS:
   - command: pip install flake8-bugbear==22.3.23 mccabe==0.6.1
 PYTHON_ISORT_CONFIG_FILE: LINTER_DEFAULT


### PR DESCRIPTION
Otherwise, `.markdownlint.yaml` is not found.