### PR TITLE
chore(Node.js): Pin version via asdf

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,3 @@
+nodejs 16.14.2
 python 3.9.7
 poetry 1.1.13

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,7 @@
 
 - Close and relaunch Ubuntu to source your `~/.bashrc`.
 - [Install Python's build dependencies](https://github.com/pyenv/pyenv/wiki#suggested-build-environment).
+- Run `asdf plugin add nodejs` to install the Node.js plugin for asdf.
 - Run `asdf plugin add python` to install the Python plugin for asdf.
 - Run `asdf plugin add poetry` to install the Poetry plugin for asdf.
 - Change directories to the root of this repository.


### PR DESCRIPTION
We depend on Node.js, because the MegaLinter pre-commit hooks use npx, which ships with npm, which ships with Node.js. Document that contributors must install the nodejs plugin for asdf.