### PR TITLE
docs(pre-commit): Keep Commitizen versions in sync

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -104,7 +104,7 @@ repos:
 
   ## Git
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: v2.24.0
+    rev: v2.24.0 # Keep in sync with pyproject.toml.
     hooks:
       - id: commitizen
         stages:


### PR DESCRIPTION
Remind maintainers to keep the Commitizen version used in the pre-commit hook in sync with the version installed in the virtualenv.