### PR TITLE
ci(bump-version): Pin version of Commitizen

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -20,6 +20,7 @@ jobs:
           git_name: commitizen-github-action[bot]
           git_email: commitizen-github-action[bot]@users.noreply.github.com
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          commitizen_version: 2.24.0 # Keep in sync with pyproject.toml.
       - name: Send Slack notification with job status.
         uses: ./
         with:


### PR DESCRIPTION
We already pin the version of Commitizen used in the pre-commit hook and installed in the virtualenv, so pin Commitizen in the bump-version workflow to the same version.