### PR TITLE
ci(pre-commit): Configure default hook types

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,9 @@
+default_install_hook_types:
+  - commit-msg
+  - post-checkout
+  - pre-commit
+  - pre-merge-commit
+  - pre-push
 default_language_version:
   python: python3.9.7
 default_stages:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,17 +40,7 @@
 - Close and relaunch Ubuntu to source your `~/.bashrc`.
 - Run `poetry install` to install all Python dependencies.
 - Run `poetry shell` to activate the Poetry virtual environment.
-- Install all pre-commit hooks by running:
-
-  ```sh
-  pre-commit install \
-    --hook-type commit-msg \
-    --hook-type post-checkout \
-    --hook-type pre-commit \
-    --hook-type pre-merge-commit \
-    --hook-type pre-push \
-    --install-hooks
-  ```
+- Install all pre-commit hooks by running `pre-commit install --install-hooks`.
 
 ## Expectations
 


### PR DESCRIPTION
Reduce the number of flags the developer must specify to set up pre-commit.