### PR TITLE
ci(GitHub-Actions): Improve job names

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -5,7 +5,7 @@ on:
       - main
 jobs:
   bump-version:
-    name: Bump version, and update changelog with commitizen.
+    name: Bump Version
     if: "!startsWith(github.event.head_commit.message, 'bump:')"
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/notify-assignee.yaml
+++ b/.github/workflows/notify-assignee.yaml
@@ -5,6 +5,7 @@ on:
       - assigned
 jobs:
   notify-assignee:
+    name: Notify Assignee
     runs-on: ubuntu-20.04
     steps:
       - name: Check out repository.

--- a/.github/workflows/notify-reviewers.yaml
+++ b/.github/workflows/notify-reviewers.yaml
@@ -5,6 +5,7 @@ on:
       - review_requested
 jobs:
   notify-reviewers:
+    name: Notify Reviewers
     runs-on: ubuntu-20.04
     steps:
       - name: Check out repository.

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,6 +8,7 @@ on:
       - main
 jobs:
   test:
+    name: Run Pre-commit Hooks
     runs-on: ubuntu-20.04
     steps:
       - name: Check out repository.


### PR DESCRIPTION
They render within a small box in the GitHub Actions UI, and hence long names are elided. When not specified, they default to the job key, so specify them.