### PR TITLE
feat(GitHub-Actions): Make most workflows callable

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -3,6 +3,19 @@ on:
   push:
     branches:
       - main
+  workflow_call:
+    secrets:
+      SLACK_BOT_TOKEN:
+        description: >
+          The Slack API bot token for your custom app. It will be used to report
+          the result of the workflow. The token must have the chat:write scope.
+        required: true
+      SLACK_ACTIONS_CHANNEL_ID:
+        description: >
+          The ID of the Slack channel to report the workflow result to. Your bot
+          should be a member. Secondary-click on the channel in Slack, and
+          select "Copy link" to copy a URL containing the channel ID.
+        required: true
 jobs:
   bump-version:
     name: Bump Version

--- a/.github/workflows/notify-assignee.yaml
+++ b/.github/workflows/notify-assignee.yaml
@@ -3,6 +3,20 @@ on:
   pull_request:
     types:
       - assigned
+  workflow_call:
+    secrets:
+      SLACK_BOT_TOKEN:
+        description: >
+          The Slack API bot token for your custom app. It will be used to issue
+          a notification that a pull request was assigned. The token must have
+          the chat:write scope.
+        required: true
+      SLACK_ASSIGN_CHANNEL_ID:
+        description: >
+          The ID of the Slack channel to send the pull request assignment to.
+          Your bot should be a member. Secondary-click on the channel in Slack,
+          and select "Copy link" to copy a URL containing the channel ID.
+        required: true
 jobs:
   notify-assignee:
     name: Notify Assignee

--- a/.github/workflows/notify-reviewers.yaml
+++ b/.github/workflows/notify-reviewers.yaml
@@ -3,6 +3,21 @@ on:
   pull_request:
     types:
       - review_requested
+  workflow_call:
+    secrets:
+      SLACK_BOT_TOKEN:
+        description: >
+          The Slack API bot token for your custom app. It will be used to
+          request review of a pull request. The token must have the chat:write
+          scope.
+        required: true
+      SLACK_REVIEW_CHANNEL_ID:
+        description: >
+          The ID of the Slack channel to use to request review of a pull
+          request. Your bot should be a member. Secondary-click on the channel
+          in Slack, and select "Copy link" to copy a URL containing the channel
+          ID.
+        required: true
 jobs:
   notify-reviewers:
     name: Notify Reviewers


### PR DESCRIPTION
Permit the `bump-version`, `notify-assignee`, and `notify-reviewers` workflows to be reused by other repositories.