### PR TITLE
fix(GitHub-Actions): Specify to checkout this repo

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -25,6 +25,7 @@ jobs:
       - name: Check out repository.
         uses: actions/checkout@v3.0.1
         with:
+          repository: ScribeMD/slack-templates
           fetch-depth: 0
       - name: Push a commit to main to bump version and update changelog.
         uses: commitizen-tools/commitizen-action@0.12.0

--- a/.github/workflows/notify-assignee.yaml
+++ b/.github/workflows/notify-assignee.yaml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Check out repository.
         uses: actions/checkout@v3.0.1
+        with:
+          repository: ScribeMD/slack-templates
       - name: Send Slack notification assigning pull request.
         uses: ./
         with:

--- a/.github/workflows/notify-reviewers.yaml
+++ b/.github/workflows/notify-reviewers.yaml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Check out repository.
         uses: actions/checkout@v3.0.1
+        with:
+          repository: ScribeMD/slack-templates
       - name: Send Slack notification requesting code review.
         uses: ./
         with:


### PR DESCRIPTION
In called workflows, the repository of the caller workflow is checked out by default. Since our callable workflows run the action of the current repository (`./`), that action is only `slack-templates` when the workflow is used or called within `slack-templates`. Otherwise, it is the action of the caller workflow's repository, which presumably does not send a Slack notification.