### PR TITLE
fix(GitHub-Actions): Pin slack-templates

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -25,7 +25,6 @@ jobs:
       - name: Check out repository.
         uses: actions/checkout@v3.0.1
         with:
-          repository: ScribeMD/slack-templates
           fetch-depth: 0
       - name: Push a commit to main to bump version and update changelog.
         uses: commitizen-tools/commitizen-action@0.12.0
@@ -36,7 +35,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           commitizen_version: 2.24.0 # Keep in sync with pyproject.toml.
       - name: Send Slack notification with job status.
-        uses: ./
+        uses: ScribeMD/slack-templates@0.2.1
         with:
           bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           channel-id: ${{ secrets.SLACK_ACTIONS_CHANNEL_ID }}

--- a/.github/workflows/notify-assignee.yaml
+++ b/.github/workflows/notify-assignee.yaml
@@ -22,12 +22,8 @@ jobs:
     name: Notify Assignee
     runs-on: ubuntu-20.04
     steps:
-      - name: Check out repository.
-        uses: actions/checkout@v3.0.1
-        with:
-          repository: ScribeMD/slack-templates
       - name: Send Slack notification assigning pull request.
-        uses: ./
+        uses: ScribeMD/slack-templates@0.2.1
         with:
           bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           channel-id: ${{ secrets.SLACK_ASSIGN_CHANNEL_ID }}

--- a/.github/workflows/notify-reviewers.yaml
+++ b/.github/workflows/notify-reviewers.yaml
@@ -23,12 +23,8 @@ jobs:
     name: Notify Reviewers
     runs-on: ubuntu-20.04
     steps:
-      - name: Check out repository.
-        uses: actions/checkout@v3.0.1
-        with:
-          repository: ScribeMD/slack-templates
       - name: Send Slack notification requesting code review.
-        uses: ./
+        uses: ScribeMD/slack-templates@0.2.1
         with:
           bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           channel-id: ${{ secrets.SLACK_REVIEW_CHANNEL_ID }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,9 @@ build-backend = "poetry.core.masonry.api"
   [tool.commitizen]
   version = "0.2.1"
   version_files = [
+    ".github/workflows/bump-version.yaml:slack-templates@",
+    ".github/workflows/notify-assignee.yaml:slack-templates@",
+    ".github/workflows/notify-reviewers.yaml:slack-templates@",
     "pyproject.toml:version",
     "README.md:slack-templates@"
   ]


### PR DESCRIPTION
When caller workflows specify a version of slack-templates when calling a workflow, they expect that version of `slack-templates` to be used. Don't circumvent that expectation by always using the version on main. Also, don't explicitly check out `slack-templates` in the Bump Version workflow since this causes Commitizen to attempt to bump the version of `slack-templates` rather than the version of the caller workflow's repository. This will always fail when the calling workflow is housed in another repository, because there will never be any new commits to `slack-templates` on main relative to the commits on main. Use Commitizen to keep the version of `slack-templates` used in the callable workflows in sync with the version of the `slack-templates` repository.