### PR TITLE
fix(GitHub-Actions): Don't pin slack-templates

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -22,7 +22,7 @@ jobs:
     if: "!startsWith(github.event.head_commit.message, 'bump:')"
     runs-on: ubuntu-20.04
     steps:
-      - name: Check out repository.
+      - name: Check out caller's repository.
         uses: actions/checkout@v3.0.1
         with:
           fetch-depth: 0
@@ -34,8 +34,13 @@ jobs:
           git_email: commitizen-github-action[bot]@users.noreply.github.com
           github_token: ${{ secrets.GITHUB_TOKEN }}
           commitizen_version: 2.24.0 # Keep in sync with pyproject.toml.
+      - name: Check out slack-templates.
+        uses: actions/checkout@v3.0.1
+        with:
+          repository: ScribeMD/slack-templates
+          path: slack-templates
       - name: Send Slack notification with job status.
-        uses: ScribeMD/slack-templates@0.2.1
+        uses: ./slack-templates/
         with:
           bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           channel-id: ${{ secrets.SLACK_ACTIONS_CHANNEL_ID }}

--- a/.github/workflows/notify-assignee.yaml
+++ b/.github/workflows/notify-assignee.yaml
@@ -22,8 +22,12 @@ jobs:
     name: Notify Assignee
     runs-on: ubuntu-20.04
     steps:
+      - name: Check out slack-templates.
+        uses: actions/checkout@v3.0.1
+        with:
+          repository: ScribeMD/slack-templates
       - name: Send Slack notification assigning pull request.
-        uses: ScribeMD/slack-templates@0.2.1
+        uses: ./
         with:
           bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           channel-id: ${{ secrets.SLACK_ASSIGN_CHANNEL_ID }}

--- a/.github/workflows/notify-reviewers.yaml
+++ b/.github/workflows/notify-reviewers.yaml
@@ -23,8 +23,12 @@ jobs:
     name: Notify Reviewers
     runs-on: ubuntu-20.04
     steps:
+      - name: Check out slack-templates.
+        uses: actions/checkout@v3.0.1
+        with:
+          repository: ScribeMD/slack-templates
       - name: Send Slack notification requesting code review.
-        uses: ScribeMD/slack-templates@0.2.1
+        uses: ./
         with:
           bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           channel-id: ${{ secrets.SLACK_REVIEW_CHANNEL_ID }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,9 +9,6 @@ build-backend = "poetry.core.masonry.api"
   [tool.commitizen]
   version = "0.2.1"
   version_files = [
-    ".github/workflows/bump-version.yaml:slack-templates@",
-    ".github/workflows/notify-assignee.yaml:slack-templates@",
-    ".github/workflows/notify-reviewers.yaml:slack-templates@",
     "pyproject.toml:version",
     "README.md:slack-templates@"
   ]


### PR DESCRIPTION
For security reasons and to avoid runaway recursion, the token GitHub generates for GitHub Actions doesn't have permission to modify workflows themselves. Hence, the Bump Version workflow fails when attempting to bump the version of `slack-templates` in our callable workflows. Workflows may only be bumped by using a personal access token with the workflow scope. While we could document this and require callers to pass the personal access token of an arbitrary developer on their project, that would greatly increase the liability and risk taken by all parties involved. Revert to leaving the version of `slack-templates` unpinned for now. Take care to check the `slack-templates` repository out separately in the Bump Version workflow so that the `slack-templates` action is run and not the caller's action.