### PR TITLE
ci(MegaLinter): Disable GraphQL schema linter

### DIFF
--- a/.mega-linter.yaml
+++ b/.mega-linter.yaml
@@ -2,7 +2,8 @@ APPLY_FIXES: all
 DEFAULT_BRANCH: main
 # We use the .graphql extension for queries, not schemas, for the sake of syntax
 # highlighting.
-DISABLE_LINTERS: GRAPHQL_GRAPHQL_SCHEMA_LINTER
+DISABLE_LINTERS: # Overridden by .pre-commit-config.yaml on git commit.
+  - GRAPHQL_GRAPHQL_SCHEMA_LINTER
 FAIL_IF_MISSING_LINTER_IN_FLAVOR: true
 FORMATTERS_DISABLE_ERRORS: false
 PRINT_ALPACA: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,9 +24,15 @@ repos:
       - id: poetry-install
       - id: pre-commit-install
       - id: megalinter
-        args: &megalinter-args [--flavor, python, --release, v5.11.0]
+        args:
+          - --env
+          - "'DISABLE_LINTERS=COPYPASTE_JSCPD,GRAPHQL_GRAPHQL_SCHEMA_LINTER'"
+          - --flavor
+          - python
+          - --release
+          - v5.11.0
       - id: megalinter-all
-        args: *megalinter-args
+        args: [--flavor, python, --release, v5.11.0]
 
   ## Python
   - repo: https://github.com/pre-commit/mirrors-autopep8


### PR DESCRIPTION
It was previously disabled for pushes, but not for commits, because the configuration variable in `.mega-linter.yaml` was overridden by the environment variable in the incremental pre-commit hook. Disable GraphQL schema linter explicitly on the command line to prevent the setting from being overridden. Prefer array syntax for disabling linters since an array is more easily extended than a single comma-delimited string.