### PR TITLE
chore(CSpell): Remove terms added upstream

### DIFF
--- a/.dictionary.txt
+++ b/.dictionary.txt
@@ -1,5 +1,3 @@
 Laven
-Markdownlint
-MegaLinter
 requestee
 slackapi

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -9,4 +9,5 @@ dictionaryDefinitions:
 dictionaries:
   - custom
   - fullstack
+  - npm
   - python


### PR DESCRIPTION
Also, use the npm dictionary, which now contains "markdownlint."