### PR TITLE
docs(pre-commit): Keep tool versions in sync

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ default_install_hook_types:
   - pre-merge-commit
   - pre-push
 default_language_version:
-  python: python3.9.7
+  python: python3.9.7 # Keep in sync with .tool-versions and pyproject.toml.
 default_stages:
   - commit
   - push

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 nodejs 16.14.2
-python 3.9.7
+python 3.9.7 # Keep in sync with .pre-commit-config.yaml and pyproject.toml.
 poetry 1.1.13

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,11 +34,12 @@ build-backend = "poetry.core.masonry.api"
   license = "MIT"
 
   [tool.poetry.dependencies]
+  # Keep in sync with .pre-commit-config.yaml and .tool-versions.
   python = "^3.9.7"
 
   [tool.poetry.dev-dependencies]
   bandit = "^1.7.4"
-  commitizen = "^2.24.0"
+  commitizen = "^2.24.0" # Keep in sync with .pre-commit-config.yaml.
   flake8 = "^4.0.1"
   flake8-black = "^0.3.2"
   flake8-bugbear = "^22.3.23"


### PR DESCRIPTION
Remind maintainers to keep the Python and Commitizen versions used in sync since they are listed in several places.