### PR TITLE
ci(markdown-link-check): Accept any compression

### DIFF
--- a/.dictionary.txt
+++ b/.dictionary.txt
@@ -1,3 +1,4 @@
 Laven
 requestee
 slackapi
+zstd

--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -1,7 +1,10 @@
 {
-  "ignorePatterns": [
+  "httpHeaders": [
     {
-      "pattern": "^https://docs.github.com/"
+      "urls": [""],
+      "headers": {
+        "Accept-Encoding": "zstd;q=1, br;q=0.9, gzip;q=0.8, deflate;q=0.7, compress;q=0.6, *;q=0.1, identity;q=0"
+      }
     }
   ]
 }


### PR DESCRIPTION
Eliminate the need to suppress 400s when checking docs.github.com links.