### PR TITLE
docs(Commitizen): Keep versions in sync

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -33,7 +33,7 @@ jobs:
           git_name: commitizen-github-action[bot]
           git_email: commitizen-github-action[bot]@users.noreply.github.com
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          commitizen_version: 2.24.0 # Keep in sync with pyproject.toml.
+          commitizen_version: 2.24.0 # Keep in sync with .pre-commit-config.yaml and pyproject.toml.
       - name: Send Slack notification with job status (self-test).
         if: ${{ github.repository == 'ScribeMD/slack-templates' }}
         uses: ./

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -116,7 +116,7 @@ repos:
 
   ## Git
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: v2.24.0 # Keep in sync with pyproject.toml.
+    rev: v2.24.0 # Keep in sync with bump-version.yaml and pyproject.toml.
     hooks:
       - id: commitizen
         stages:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ build-backend = "poetry.core.masonry.api"
 
   [tool.poetry.dev-dependencies]
   bandit = "^1.7.4"
-  commitizen = "^2.24.0" # Keep in sync with .pre-commit-config.yaml.
+  commitizen = "^2.24.0" # Keep in sync with .pre-commit-config.yaml and bump-version.yaml.
   flake8 = "^4.0.1"
   flake8-black = "^0.3.2"
   flake8-bugbear = "^22.3.23"


### PR DESCRIPTION
Remind maintainers to keep the Commitizen version used in the Bump Version workflow in sync with the versions used in the pre-commit hook and installed in the virtualenv. The workflow mentioned the virtualenv, but neither of the latter comments mentioned the workflow.