### PR TITLE
ci(workflow): Check out full repository history

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Check out repository.
         uses: actions/checkout@v3.0.2
+        with:
+          fetch-depth: 0
       - name: Run pre-commit hooks.
         uses: ScribeMD/pre-commit-action@0.6.0
       - name: Send Slack notification with job status.


### PR DESCRIPTION
In the Test workflow, the pre-commit-action now runs the Commitizen action, which relies on Git tags. The official GitHub checkout action does a sparse checkout by default, which does not include tags, causing version bumps to fail. Pass `fetch-depth: 0` to instruct the checkout action to perform a full checkout, including tags.