### PR TITLE
docs(Commitizen): Don't mention `bump-version.yaml`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -116,7 +116,7 @@ repos:
 
   ## Git
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: v2.24.0 # Keep in sync with bump-version.yaml and pyproject.toml.
+    rev: v2.24.0 # Keep in sync with pyproject.toml.
     hooks:
       - id: commitizen
         stages:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ build-backend = "poetry.core.masonry.api"
 
   [tool.poetry.dev-dependencies]
   bandit = "^1.7.4"
-  commitizen = "^2.24.0" # Keep in sync with .pre-commit-config.yaml and bump-version.yaml.
+  commitizen = "^2.24.0" # Keep in sync with .pre-commit-config.yaml.
   flake8 = "^4.0.1"
   flake8-black = "^0.3.2"
   flake8-bugbear = "^22.3.23"


### PR DESCRIPTION
Update comments reminding maintainers to keep the Commitizen version in sync now that the Bump Version workflow has been deleted.