### PR TITLE
chore(MegaLinter): Upgrade from v5.12.0 to v5.13.0

### DIFF
--- a/.dictionary.txt
+++ b/.dictionary.txt
@@ -1,4 +1,4 @@
+fullmatch
 Laven
 requestee
 slackapi
-zstd

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
 
   ## Python, Polyglot, Git, pre-commit
   - repo: https://github.com/ScribeMD/pre-commit-hooks
-    rev: 0.4.0
+    rev: 0.5.0
     hooks:
       - id: no-merge-commits
       - id: asdf-install

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,9 +30,9 @@ repos:
           - --flavor
           - python
           - --release
-          - v5.12.0
+          - v5.13.0
       - id: megalinter-all
-        args: [--flavor, python, --release, v5.12.0]
+        args: [--flavor, python, --release, v5.13.0]
 
   ## Python
   - repo: https://github.com/pre-commit/mirrors-autopep8


### PR DESCRIPTION
Add "fullmatch" to custom dictionary since the Python dictionary no longer allows arbitrary compounding of words by default. Remove "zstd" from custom dictionary, which was added to the fullstack dictionary upstream.

Upgrade all pre-commit hooks to latest.

ScribeMD/pre-commit-hooks 0.4.0 --> 0.5.0