### PR TITLE
chore(Python): Upgrade all dependencies to latest

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -116,11 +116,9 @@ repos:
 
   ## Git
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: v2.27.0 # Keep in sync with pyproject.toml.
+    rev: v2.27.1 # Keep in sync with pyproject.toml.
     hooks:
       - id: commitizen
-        stages:
-          - commit-msg
   - repo: https://github.com/jumanjihouse/pre-commit-hooks
     rev: 2.1.6
     hooks:

--- a/poetry.lock
+++ b/poetry.lock
@@ -106,7 +106,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "commitizen"
-version = "2.27.0"
+version = "2.27.1"
 description = "Python commitizen client tool"
 category = "dev"
 optional = false
@@ -134,11 +134,11 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "dill"
-version = "0.3.4"
+version = "0.3.5.1"
 description = "serialize all of python"
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, !=3.6.*"
 
 [package.extras]
 graph = ["objgraph (>=1.7.2)"]
@@ -614,7 +614,7 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 [metadata]
 lock-version = "1.1"
   python-versions = "^3.9.7"
-content-hash = "f29d484fc8072791ef0b39b4f7500053c5f1e49213c4c912f89d6544f51469c9"
+content-hash = "c3fbf07fbe37b26ff2a31f00aa999c793c0cf7a94753e67376df8dd5ca3d5b32"
 
 [metadata.files]
 argcomplete = [
@@ -671,16 +671,16 @@ colorama = [
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
 commitizen = [
-    {file = "commitizen-2.27.0-py3-none-any.whl", hash = "sha256:846d8caf903499d3bf48a834cdc95dad48cd7e91a62717c4649f879e248348ae"},
-    {file = "commitizen-2.27.0.tar.gz", hash = "sha256:ef18cfbf68df38b313f63ede2532dbbc62800030539544f4876a829897abd86c"},
+    {file = "commitizen-2.27.1-py3-none-any.whl", hash = "sha256:046d512c5bc795cce625211434721946f21abf713f48753f2353ec1a3e114c3f"},
+    {file = "commitizen-2.27.1.tar.gz", hash = "sha256:71a3e1fea37ced781bc440bd7d464abd5b797da8e762c1b9b632e007c2019b50"},
 ]
 decli = [
     {file = "decli-0.5.2-py3-none-any.whl", hash = "sha256:d3207bc02d0169bf6ed74ccca09ce62edca0eb25b0ebf8bf4ae3fb8333e15ca0"},
     {file = "decli-0.5.2.tar.gz", hash = "sha256:f2cde55034a75c819c630c7655a844c612f2598c42c21299160465df6ad463ad"},
 ]
 dill = [
-    {file = "dill-0.3.4-py2.py3-none-any.whl", hash = "sha256:7e40e4a70304fd9ceab3535d36e58791d9c4a776b38ec7f7ec9afc8d3dca4d4f"},
-    {file = "dill-0.3.4.zip", hash = "sha256:9f9734205146b2b353ab3fec9af0070237b6ddae78452af83d2fca84d739e675"},
+    {file = "dill-0.3.5.1-py2.py3-none-any.whl", hash = "sha256:33501d03270bbe410c72639b350e941882a8b0fd55357580fbc873fba0c59302"},
+    {file = "dill-0.3.5.1.tar.gz", hash = "sha256:d75e41f3eff1eee599d738e76ba8f4ad98ea229db8b085318aa2b3333a208c86"},
 ]
 distlib = [
     {file = "distlib-0.3.4-py2.py3-none-any.whl", hash = "sha256:6564fe0a8f51e734df6333d08b8b94d4ea8ee6b99b5ed50613f731fd4089f34b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ build-backend = "poetry.core.masonry.api"
 
   [tool.poetry.dev-dependencies]
   bandit = "^1.7.4"
-  commitizen = "^2.27.0" # Keep in sync with .pre-commit-config.yaml.
+  commitizen = "^2.27.1" # Keep in sync with .pre-commit-config.yaml.
   flake8 = "^4.0.1"
   flake8-black = "^0.3.3"
   flake8-bugbear = "^22.4.25"


### PR DESCRIPTION
Upgrade all transitive dependencies as well. The `commitizen` pre-commit hook now specifies that it runs on the `commit-msg` stage upstream, so stop specifying the hook stage here.

commitizen ^2.27.0 --> ^2.27.1