### PR TITLE
fix(SlackNotification): Get PR# from event payload

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -54,6 +54,7 @@ runs:
         "${{ github.event.pull_request.user.login }}"
         "*${{ join(github.event.pull_request.requested_reviewers.*.login, '*, *') }}*"
         "${{ github.event.pull_request.assignee.login }}"
+        "${{ github.event.pull_request.number }}"
       shell: bash
       working-directory: "${{ github.action_path }}"
     - name: Send Slack notification.

--- a/set_slack_message.py
+++ b/set_slack_message.py
@@ -3,7 +3,7 @@
 """Set Slack message for GitHub Action.
 
 Usage: python set_slack_message.py \
-    <template> <results> <message> <token> <author> <reviewers> <assignee>
+    <template> <results> <message> <token> <author> <reviewers> <assignee> <pr_number>
 """
 import sys
 

--- a/src/cli.py
+++ b/src/cli.py
@@ -16,13 +16,28 @@ def get_slack_notification(arguments: Sequence[str]) -> SlackNotification:
     the first element of sys.argv since this is merely the name of the Python script
     itself.
     """
-    template, results, message, token, author, reviewers, assignee = arguments
+    (
+        template,
+        results,
+        message,
+        token,
+        author,
+        reviewers,
+        assignee,
+        pr_number_str,
+    ) = arguments
+
     if template == "result":
-        return WorkflowResult(token, results.split())
+        try:
+            pr_number = int(pr_number_str)
+        except ValueError:
+            # GitHub only sends the pull request number for pull_request events.
+            pr_number = None
+        return WorkflowResult(token, results.split(), pr_number)
     if template == "reviewers":
-        return ReviewersAssignment(token, reviewers, author)
+        return ReviewersAssignment(token, reviewers, author, int(pr_number_str))
     if template == "assignee":
-        return PullRequestAssignment(token, assignee, author)
+        return PullRequestAssignment(token, assignee, author, int(pr_number_str))
     if template == "custom":
         return CustomNotification(token, message)
     return CustomNotification(

--- a/src/pull_request_assignment.py
+++ b/src/pull_request_assignment.py
@@ -12,7 +12,7 @@ class PullRequestAssignment(SlackNotification):
     get_message(): Return a message assigning a pull request.
     """
 
-    def __init__(self, token: str, assignee: str, author: str):
+    def __init__(self, token: str, assignee: str, author: str, pr_number: int):
         """Construct a SlackNotification for assignment of a pull request.
 
         token: the token to use to authenticate to the GitHub API. Obtain from
@@ -21,8 +21,10 @@ class PullRequestAssignment(SlackNotification):
         '${{ github.event.pull_request.assignee.login }}' in the workflow.
         author: the GitHub user who authored the pull request. Obtain from
         '${{ github.event.pull_request.user.login }}' in the workflow.
+        pr_number: the pull request number. Obtain from
+        '${{ github.event.pull_request.number }}' in the workflow.
         """
-        super().__init__(token)
+        super().__init__(token, pr_number)
         self._assignee = assignee
         self._author = author
 

--- a/src/reviewers_assignment.py
+++ b/src/reviewers_assignment.py
@@ -12,7 +12,7 @@ class ReviewersAssignment(SlackNotification):
     get_message(): Return a message assigning reviewers for a pull request.
     """
 
-    def __init__(self, token: str, reviewers: str, author: str):
+    def __init__(self, token: str, reviewers: str, author: str, pr_number: int):
         """Construct a SlackNotification for assignment of code reviewers.
 
         token: the token to use to authenticate to the GitHub API. Obtain from
@@ -22,8 +22,10 @@ class ReviewersAssignment(SlackNotification):
         in the workflow.
         author: the GitHub user who authored the pull request. Obtain from
         '${{ github.event.pull_request.user.login }}' in the workflow.
+        pr_number: the pull request number. Obtain from
+        '${{ github.event.pull_request.number }}' in the workflow.
         """
-        super().__init__(token)
+        super().__init__(token, pr_number)
         self._reviewers = reviewers
         self._author = author
 

--- a/src/workflow_result.py
+++ b/src/workflow_result.py
@@ -1,5 +1,6 @@
 """Offer WorkflowResult class."""
 from collections.abc import Sequence
+from typing import Optional
 
 from .slack_notification import SlackNotification
 
@@ -14,7 +15,9 @@ class WorkflowResult(SlackNotification):
     get_message(): Return a message reporting the result of a CI workflow.
     """
 
-    def __init__(self, token: str, job_results: Sequence[str]):
+    def __init__(
+        self, token: str, job_results: Sequence[str], pr_number: Optional[int] = None
+    ):
         """Construct a SlackNotification for the result of a CI workflow.
 
         token: the token to use to authenticate to the GitHub API. Obtain from
@@ -22,8 +25,10 @@ class WorkflowResult(SlackNotification):
         job_results: the results of the jobs in the workflow. Obtain from
         "${{ join(needs.*.result, ' ') }}" or '${{ job.status }}' in the workflow.
         Alternatively, pass a single custom result.
+        pr_number: the pull request number if applicable. Obtain from
+        '${{ github.event.pull_request.number }}' in the workflow.
         """
-        super().__init__(token)
+        super().__init__(token, pr_number)
         self._job_results = job_results
 
     def get_message(self) -> str:


### PR DESCRIPTION
For `pull_request` events, we used to get the pull request number from `GITHUB_REF_NAME`, but when the pull request has already been merged, `GITHUB_REF_NAME` instead contains the name of the base (a.k.a., to) branch. The `pull_request` event payload always contains the pull request number, so read it from there instead. Continue getting the pull request number from the GraphQL API for push events. Leverage the new `_pr_number` instance variable to cache the first successful attempt to get the pull request number from the GraphQL API.