### PR TITLE
docs(action): Keep Python versions in sync

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,8 @@ default_install_hook_types:
   - pre-merge-commit
   - pre-push
 default_language_version:
-  python: python3.9.7 # Keep in sync with .tool-versions and pyproject.toml.
+  # Keep in sync with .tool-versions, action.yaml, and pyproject.toml.
+  python: python3.9.7
 default_stages:
   - commit
   - push

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 nodejs 16.15.0
-python 3.9.7 # Keep in sync with .pre-commit-config.yaml and pyproject.toml.
+python 3.9.7 # Keep in sync with .pre-commit-config.yaml, action.yaml, and pyproject.toml.
 poetry 1.1.13

--- a/action.yaml
+++ b/action.yaml
@@ -42,7 +42,8 @@ runs:
     - name: Set up Python.
       uses: actions/setup-python@v3.1.2
       with:
-        # Keep in sync with .tool-versions.
+        # Keep in sync with .pre-commit-config.yaml, .tool-versions, and
+        # pyproject.toml.
         python-version: 3.9.7
     - name: Configure Slack notification.
       run: >

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ build-backend = "poetry.core.masonry.api"
   license = "MIT"
 
   [tool.poetry.dependencies]
-  # Keep in sync with .pre-commit-config.yaml and .tool-versions.
+  # Keep in sync with .pre-commit-config.yaml, .tool-versions, and action.yaml.
   python = "^3.9.7"
 
   [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Remind maintainers to keep the Python version used in development and CI in sync with the version used in the action.