### PR TITLE
feat(GitHub-Actions): Upgrade to latest versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,8 +5,7 @@ default_install_hook_types:
   - pre-merge-commit
   - pre-push
 default_language_version:
-  # Keep in sync with .tool-versions, action.yaml, and pyproject.toml.
-  python: python3.9.7
+  python: python3.9.7 # Keep in sync with .tool-versions and pyproject.toml.
 default_stages:
   - commit
   - push

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 nodejs 16.15.0
-python 3.9.7 # Keep in sync with .pre-commit-config.yaml, action.yaml, and pyproject.toml.
+python 3.9.7 # Keep in sync with .pre-commit-config.yaml and pyproject.toml.
 poetry 1.1.13

--- a/action.yaml
+++ b/action.yaml
@@ -39,12 +39,18 @@ branding:
 runs:
   using: composite
   steps:
-    - name: Set up Python.
-      uses: actions/setup-python@v3.1.2
-      with:
-        # Keep in sync with .pre-commit-config.yaml, .tool-versions, and
-        # pyproject.toml.
-        python-version: 3.9.7
+    - name: Write Python version file based on asdf Python version.
+      run: >
+        grep
+        --perl-regexp
+        --only-matching
+        "(?<=python )(\d+\.){2}\d+"
+        .tool-versions
+        >.python-version
+      shell: bash
+      working-directory: "${{ github.action_path }}"
+    - name: Set up Python based on Python version file.
+      uses: actions/setup-python@v4.0.0
     - name: Configure Slack notification.
       run: >
         python set_slack_message.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ build-backend = "poetry.core.masonry.api"
   license = "MIT"
 
   [tool.poetry.dependencies]
-  # Keep in sync with .pre-commit-config.yaml, .tool-versions, and action.yaml.
+  # Keep in sync with .pre-commit-config.yaml and .tool-versions.
   python = "^3.9.7"
 
   [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Eliminate the need to hard-code the Python version used by the action by leveraging setup-python's newly added support for reading the Python version from a file.

actions/setup-python v3.1.2 --> v4.0.0