### PR TITLE
fix(action): Specify Python version directly

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -39,18 +39,17 @@ branding:
 runs:
   using: composite
   steps:
-    - name: Write Python version file based on asdf Python version.
-      run: >
-        grep
-        --perl-regexp
-        --only-matching
-        "(?<=python )(\d+\.){2}\d+"
-        .tool-versions
-        >.python-version
+    - id: python
+      name: Read asdf Python version from .tool-versions.
+      run: |
+        python_version="$(grep --perl-regexp --only-matching "(?<=python )(\d+\.){2}\d+" .tool-versions)"
+        echo "::set-output name=version::$python_version"
       shell: bash
       working-directory: "${{ github.action_path }}"
-    - name: Set up Python based on Python version file.
+    - name: Set up Python based on asdf Python version.
       uses: actions/setup-python@v4.0.0
+      with:
+        python-version: "${{ steps.python.outputs.version }}"
     - name: Configure Slack notification.
       run: >
         python set_slack_message.py


### PR DESCRIPTION
Fix crash when running slack-templates action from other repositories. The setup-python action incorrectly prepends the path of the calling action checkout to the given `python-version-file`. Hence, the Python version file is only found correctly when slack-templates is called within this repository. Work around this bug by passing `python-version` instead without creating a Python version file at all.