### PR TITLE
chore(MegaLinter): Upgrade from v5.13.0 to v5.14.0

### DIFF
--- a/.dictionary.txt
+++ b/.dictionary.txt
@@ -1,5 +1,3 @@
-dataclass
-fullmatch
 Laven
 requestee
 slackapi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
 
   ## Python, Polyglot, Git, pre-commit
   - repo: https://github.com/ScribeMD/pre-commit-hooks
-    rev: 0.5.2
+    rev: 0.6.1
     hooks:
       - id: no-merge-commits
       - id: asdf-install

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,9 +31,9 @@ repos:
           - --flavor
           - python
           - --release
-          - v5.13.0
+          - v5.14.0
       - id: megalinter-all
-        args: [--flavor, python, --release, v5.13.0]
+        args: [--flavor, python, --release, v5.14.0]
 
   ## Python
   - repo: https://github.com/pre-commit/mirrors-autopep8


### PR DESCRIPTION
Remove "dataclass" and "fullmatch" from custom dictionary; they were added to the Python dictionary upstream.

Upgrade all pre-commit hooks to latest versions.

ScribeMD/pre-commit-hooks 0.5.2 --> 0.6.1