### PR TITLE
fix(workflow): Grant minimum necessary scopes

### DIFF
--- a/.github/workflows/notify-assignee.yaml
+++ b/.github/workflows/notify-assignee.yaml
@@ -21,6 +21,8 @@ jobs:
   notify-assignee:
     name: Notify Assignee
     runs-on: ubuntu-20.04
+    permissions:
+      contents: read # for actions/checkout in private repositories
     steps:
       - name: Check out slack-templates.
         uses: actions/checkout@v3.0.2

--- a/.github/workflows/notify-reviewers.yaml
+++ b/.github/workflows/notify-reviewers.yaml
@@ -22,6 +22,8 @@ jobs:
   notify-reviewers:
     name: Notify Reviewers
     runs-on: ubuntu-20.04
+    permissions:
+      contents: read # for actions/checkout in private repositories
     steps:
       - name: Check out slack-templates.
         uses: actions/checkout@v3.0.2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,6 +10,8 @@ jobs:
   test:
     name: Run Pre-commit Hooks
     runs-on: ubuntu-20.04
+    permissions:
+      contents: write # for pre-commit-action
     steps:
       - name: Check out repository.
         uses: actions/checkout@v3.0.2


### PR DESCRIPTION
pre-commit-action requires the `contents:write scope`, and actions/checkout requires the `contents:read` scope. pre-commit-action uses the `contents:write` scope to bump the project version via Commitizen. actions/checkout uses the `contents:read` scope to check out the calling repository. Granting these specific permissions also has the effect of reducing the scope of all unspecified permissions from read to none for pull requests from Dependabot and forks and from write to none for workflows triggered by anything else (even re-runs of Dependabot pull requests). Since this repository is public, most of its data can be read without additional permissions, but the `contents:read` scope is needed when the calling repository is private.