### PR TITLE
docs(README): Use Coolors' suggestions for badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # slack-templates
 
 [![Test Workflow Status](https://github.com/ScribeMD/slack-templates/workflows/Test/badge.svg)](https://github.com/ScribeMD/slack-templates/actions/workflows/test.yaml)
-[![Git Hooks: pre-commit](https://img.shields.io/badge/pre--commit-Git_Hooks-orange?logo=precommit&logoColor=FAB040)](https://pre-commit.com/)
-[![Commit Style: Conventional Commits](https://img.shields.io/badge/Conventional_Commits-Commit_Style-yellow?logo=conventionalcommits&logoColor=FE5196)](https://conventionalcommits.org)
-[![Code Style: Prettier](https://img.shields.io/badge/Prettier-Code_Style-FF69B4?logo=prettier&logoColor=F7B93E)](https://prettier.io/)
+[![Git Hooks: pre-commit](https://img.shields.io/badge/pre--commit-Git_Hooks-66A182?logo=precommit&logoColor=FAB040)](https://pre-commit.com/)
+[![Commit Style: Conventional Commits](https://img.shields.io/badge/Conventional_Commits-Commit_Style-F39237?logo=conventionalcommits&logoColor=FE5196)](https://conventionalcommits.org)
+[![Code Style: Prettier](https://img.shields.io/badge/Prettier-Code_Style-758ECD?logo=prettier&logoColor=F7B93E)](https://prettier.io/)
 [![Code Style: Black](https://img.shields.io/badge/Black-Code_Style-000)](https://github.com/psf/black)
 [![Imports: isort](https://img.shields.io/badge/isort-Imports-1674B1)](https://pycqa.github.io/isort/)
 [![Security: Bandit](https://img.shields.io/badge/Bandit-Security-yellow)](https://github.com/PyCQA/bandit)


### PR DESCRIPTION
For badges with logos, configure [Coolors](https://coolors.co/) with the logo color as the primary color, label background color (`#555555`) as the secondary color, and text color (`#FFFFFF`) as the quaternary color. Use the first recommended tertiary color for the message background color.