### PR TITLE
ci(dictionary): Add "deps" to custom dictionary

### DIFF
--- a/.dictionary.txt
+++ b/.dictionary.txt
@@ -1,3 +1,4 @@
+deps
 Laven
 requestee
 slackapi


### PR DESCRIPTION
Dependabot uses "deps," short for "dependencies," in commit messages, which Commitizen incorporates into the changelog.