### PR TITLE
fix(Python): Upgrade from 3.9.7 to 3.9.13

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ default_install_hook_types:
   - pre-merge-commit
   - pre-push
 default_language_version:
-  python: python3.9.7 # Keep in sync with .tool-versions and pyproject.toml.
+  python: python3.9.13 # Keep in sync with .tool-versions and pyproject.toml.
 default_stages:
   - commit
   - push

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 nodejs 16.15.1
-python 3.9.7 # Keep in sync with .pre-commit-config.yaml and pyproject.toml.
+python 3.9.13 # Keep in sync with .pre-commit-config.yaml and pyproject.toml.
 poetry 1.1.15

--- a/poetry.lock
+++ b/poetry.lock
@@ -613,8 +613,8 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 
 [metadata]
 lock-version = "1.1"
-python-versions = "^3.9.7"
-content-hash = "90e28f1af750f8881bc3ab0bbec0a520f33f7af7e0319f5e9d114d4a327f272e"
+python-versions = "^3.9.13"
+content-hash = "1e949d67cf02f40a9e634c3f4af3bab8afae8ed429f7ef7e05be51afc0e202e6"
 
 [metadata.files]
 argcomplete = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ build-backend = "poetry.core.masonry.api"
 
   [tool.poetry.dependencies]
   # Keep in sync with .pre-commit-config.yaml and .tool-versions.
-  python = "^3.9.7"
+  python = "^3.9.13"
 
   [tool.poetry.dev-dependencies]
   bandit = "^1.7.4"


### PR DESCRIPTION
Python 3.10 has been released, but the Python linters in MegaLinter v5 don't support Python 3.10, because the MegaLinter v5 Docker base image is `python:3.9.7-alpine3.13`. Python 3.9.7 is not supported by `actions/setup-python` on the recently released `ubuntu-22.04` GitHub-hosted runner, whereas Python 3.9.13 currently comes pre-installed.