### PR TITLE
ci(pre-commit): Add `commitizen-branch` hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,7 @@
 default_install_hook_types:
   - commit-msg
   - post-checkout
+  - post-commit
   - post-rewrite
   - pre-commit
   - pre-merge-commit
@@ -120,6 +121,11 @@ repos:
     rev: v2.32.2 # Keep in sync with pyproject.toml.
     hooks:
       - id: commitizen
+      - id: commitizen-branch
+        stages:
+          - post-commit
+          - post-rewrite
+          - push
   - repo: https://github.com/jumanjihouse/pre-commit-hooks
     rev: 2.1.6
     hooks:


### PR DESCRIPTION
The existing `commitizen` hook checks commit messages locally at the time they are written but doesn't run in CI. The recently introduced `commitizen-branch` hook checks commit messages after the fact, so run it `post-commit`, `post-rewrite`, `pre-push`, and in CI. This also prevents empty commit messages from slipping in (e.g., via `git commit --allow-empty-message`) since the `commitizen` hook allows them to avoid false positives on aborted commits.