### PR TITLE
fix(Python): Upgrade from 3.9.13 to 3.9.14

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ default_install_hook_types:
   - pre-merge-commit
   - pre-push
 default_language_version:
-  python: python3.9.13 # Keep in sync with .tool-versions and pyproject.toml.
+  python: python3.9.14 # Keep in sync with .tool-versions and pyproject.toml.
 default_stages:
   - commit
   - push

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 nodejs 16.17.0
-python 3.9.13 # Keep in sync with .pre-commit-config.yaml and pyproject.toml.
+python 3.9.14 # Keep in sync with .pre-commit-config.yaml and pyproject.toml.
 poetry 1.2.0

--- a/poetry.lock
+++ b/poetry.lock
@@ -623,8 +623,8 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 
 [metadata]
 lock-version = "1.1"
-python-versions = "^3.9.13"
-content-hash = "0a9d6954dfcad4bd18574e545cf65346a463e58bb77e42830b9e0f1ac85cfab1"
+python-versions = "^3.9.14"
+content-hash = "fd31a728586a8824b3a4353faf5267da8f5a1e72fa63e2438b64e9c386f5d273"
 
 [metadata.files]
 argcomplete = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ build-backend = "poetry.core.masonry.api"
 
   [tool.poetry.dependencies]
   # Keep in sync with .pre-commit-config.yaml and .tool-versions.
-  python = "^3.9.13"
+  python = "^3.9.14"
 
   [tool.poetry.dev-dependencies]
   bandit = "^1.7.4"


### PR DESCRIPTION
Python 3.10 has been released, but the Python linters in MegaLinter v5 don't support Python 3.10, because the MegaLinter v5 Docker base image is `python:3.9.7-alpine3.13`.