### PR TITLE
ci(SlackNotification): Remove a mypy workaround

### DIFF
--- a/src/slack_notification.py
+++ b/src/slack_notification.py
@@ -15,8 +15,7 @@ JsonValue = None | bool | int | float | str | Sequence[Any] | Mapping[str, Any]
 JsonObject = Mapping[str, JsonValue]
 
 
-# Work around https://github.com/python/mypy/issues/5374.
-@dataclass  # type: ignore[misc]
+@dataclass
 class SlackNotification(ABC):
     """Offer utilities for issuing Slack notifications from GitHub Actions.
 


### PR DESCRIPTION
In the recently released version 0.981, mypy stopped raising a false positive on generic decorators, such as `@dataclass`, of abstract classes. Remove the no longer needed ignore directive.