### PR TITLE
style(action): Prefer `'` to `"` for string literals

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -42,7 +42,7 @@ runs:
     - id: python
       name: Read asdf Python version from .tool-versions.
       run: |
-        python_version="$(grep --perl-regexp --only-matching "(?<=python )(\d+\.){2}\d+" .tool-versions)"
+        python_version="$(grep --perl-regexp --only-matching '(?<=python )(\d+\.){2}\d+' .tool-versions)"
         echo "::set-output name=version::$python_version"
       shell: bash
       working-directory: "${{ github.action_path }}"
@@ -53,14 +53,14 @@ runs:
     - name: Configure Slack notification.
       run: >
         python set_slack_message.py
-        "${{ inputs.template }}"
-        "${{ inputs.results }}"
-        "${{ inputs.message }}"
-        "${{ github.token }}"
-        "${{ github.event.pull_request.user.login }}"
-        "*${{ join(github.event.pull_request.requested_reviewers.*.login, '*, *') }}*"
-        "${{ github.event.pull_request.assignee.login }}"
-        "${{ github.event.pull_request.number }}"
+        '${{ inputs.template }}'
+        '${{ inputs.results }}'
+        '${{ inputs.message }}'
+        '${{ github.token }}'
+        '${{ github.event.pull_request.user.login }}'
+        '*${{ join(github.event.pull_request.requested_reviewers.*.login, '*, *') }}*'
+        '${{ github.event.pull_request.assignee.login }}'
+        '${{ github.event.pull_request.number }}'
       shell: bash
       working-directory: "${{ github.action_path }}"
     - name: Send Slack notification.


### PR DESCRIPTION
Single quotes prevent evaluation of Bash syntax, such as variable interpolation, so they are simpler and safer when variable interpolation is not desired.