### PR TITLE
ci(MegaLinter): Stop overriding pre-commit args

### DIFF
--- a/.mega-linter.yaml
+++ b/.mega-linter.yaml
@@ -2,7 +2,7 @@ APPLY_FIXES: all
 DEFAULT_BRANCH: main
 # We use the .graphql extension for queries, not schemas, for the sake of syntax
 # highlighting.
-DISABLE_LINTERS: # Overridden by .pre-commit-config.yaml on git commit.
+DISABLE_LINTERS:
   - GRAPHQL_GRAPHQL_SCHEMA_LINTER
 FAIL_IF_MISSING_LINTER_IN_FLAVOR: true
 FORMATTERS_DISABLE_ERRORS: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,15 +26,9 @@ repos:
       - id: poetry-install
       - id: pre-commit-install
       - id: megalinter-incremental
-        args:
-          - --env
-          - "'DISABLE_LINTERS=COPYPASTE_JSCPD,GRAPHQL_GRAPHQL_SCHEMA_LINTER'"
-          - --flavor
-          - python
-          - --release
-          - v6.10.0
+        args: &megalinter-args [--flavor, python, --release, v6.10.0]
       - id: megalinter-full
-        args: [--flavor, python, --release, v6.10.0]
+        args: *megalinter-args
 
   ## Python
   - repo: https://github.com/pre-commit/mirrors-autopep8


### PR DESCRIPTION
This was necessary in MegaLinter v5 to run the slow jscpd pre-push but not pre-commit while always disabling graphql-schema-linter as specified in `.mega-linter.yaml`. However, MegaLinter v6 is capable of skipping all linters that run in project mode, which includes jscpd.