### PR TITLE
fix(action): Port from `set-output` to env files

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,10 +161,10 @@ jobs:
   id: network
   run: |
     ...
-    echo "::set-output name=outage::$OUTAGE"
+    echo "OUTAGE=$OUTAGE" >>"$GITHUB_OUTPUT"
   shell: bash
 - name: Send Slack notification with custom result.
-  if: always() && steps.network.outputs.outage == 'true'
+  if: always() && steps.network.outputs.OUTAGE == 'true'
   uses: ScribeMD/slack-templates@0.6.11
   with:
     bot-token: ${{ secrets.SLACK_TEMPLATES_BOT_TOKEN }}

--- a/action.yaml
+++ b/action.yaml
@@ -43,13 +43,13 @@ runs:
       name: Read asdf Python version from .tool-versions.
       run: |
         python_version="$(grep --perl-regexp --only-matching '(?<=python )(\d+\.){2}\d+' .tool-versions)"
-        echo "::set-output name=version::$python_version"
+        echo "VERSION=$python_version" >>"$GITHUB_OUTPUT"
       shell: bash
       working-directory: "${{ github.action_path }}"
     - name: Set up Python based on asdf Python version.
       uses: actions/setup-python@v4.3.0
       with:
-        python-version: "${{ steps.python.outputs.version }}"
+        python-version: "${{ steps.python.outputs.VERSION }}"
     - name: Configure Slack notification.
       run: >
         python set_slack_message.py


### PR DESCRIPTION
GitHub deprecated the `set-output` command, and recommends using the new environment files instead for security purposes.