### PR TITLE
chore(pre-commit): Upgrade all hooks to latest

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
 
   ## Python, Polyglot, Git, pre-commit
   - repo: https://github.com/ScribeMD/pre-commit-hooks
-    rev: 0.13.0
+    rev: 0.13.1
     hooks:
       - id: no-merge-commits
       - id: asdf-install
@@ -32,11 +32,11 @@ repos:
 
   ## Python
   - repo: https://github.com/pre-commit/mirrors-autopep8
-    rev: v1.6.0
+    rev: v1.7.0
     hooks:
       - id: autopep8
   - repo: https://github.com/PyCQA/docformatter
-    rev: v1.4
+    rev: v1.5.0
     hooks:
       - id: docformatter
         args: [--wrap-summaries, "88", --wrap-descriptions, "88"]
@@ -121,7 +121,7 @@ repos:
           - post-rewrite
           - push
   - repo: https://github.com/jumanjihouse/pre-commit-hooks
-    rev: 2.1.6
+    rev: 3.0.0
     hooks:
       - id: check-mailmap
       - id: forbid-binary


### PR DESCRIPTION
ScribeMD/pre-commit-hooks 0.13.0 --> 0.13.1
pre-commit/mirrors-autopep8 v1.6.0 --> v1.7.0
PyCQA/docformatter v1.4 --> v1.5.0
jumanjihouse/pre-commit-hooks 2.1.6 --> 3.0.0