### PR TITLE
chore(MegaLinter): Upgrade from v6.10.0 to v6.12.0

### DIFF
--- a/.jscpd.json
+++ b/.jscpd.json
@@ -3,7 +3,7 @@
   "maxSize": 0,
   "threshold": 0,
   "reporters": ["consoleFull", "console"],
-  "ignore": [".git", ".mypy_cache", ".venv"],
+  "ignore": ["**/.git", "**/.mypy_cache", "**/.venv"],
   "gitignore": true,
   "blame": true,
   "ignoreCase": true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
 
   ## Python, Polyglot, Git, pre-commit
   - repo: https://github.com/ScribeMD/pre-commit-hooks
-    rev: 0.13.1
+    rev: 0.14.0
     hooks:
       - id: no-merge-commits
       - id: asdf-install
@@ -26,7 +26,7 @@ repos:
       - id: poetry-install
       - id: pre-commit-install
       - id: megalinter-incremental
-        args: &megalinter-args [--flavor, python, --release, v6.10.0]
+        args: &megalinter-args [--flavor, python, --release, v6.12.0]
       - id: megalinter-full
         args: *megalinter-args
 


### PR DESCRIPTION
Upgrade ScribeMD/pre-commit-hooks from 0.13.1 to 0.14.0 for corresponding mega-linter-runner upgrade. Update jscpd ignore syntax to continue preventing jscpd from running on the `.git` directory, mypy cache, or Poetry virtual environment.