### PR TITLE
chore(Poetry): Pin all dependencies by removing `^`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -601,8 +601,8 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 
 [metadata]
 lock-version = "1.1"
-python-versions = "^3.11.0"
-content-hash = "4583752d83eb1147e334b2811cf66b4df7a597d2d41183835ab9c8696cd4d15f"
+python-versions = "3.11.0"
+content-hash = "c68d5c485bfb20f54122e2a845dac5a28f3b5509091311098ff2c0027d91c2b3"
 
 [metadata.files]
 argcomplete = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,22 +36,22 @@ build-backend = "poetry.core.masonry.api"
 
   [tool.poetry.dependencies]
   # Keep in sync with .pre-commit-config.yaml and .tool-versions.
-  python = "^3.11.0"
+  python = "3.11.0"
 
   [tool.poetry.dev-dependencies]
-  autopep8 = "^2.0.0"
-  bandit = "^1.7.4"
-  black = "^22.10.0"
-  commitizen = "^2.37.0" # Keep in sync with .pre-commit-config.yaml.
-  flake8 = "^6.0.0"
-  flake8-bugbear = "^22.10.27" # Keep in sync with .mega-linter.yaml.
-  isort = "^5.10.1"
-  mccabe = "^0.7.0" # Keep in sync with .mega-linter.yaml.
-  mypy = "^0.982"
-  pre-commit = "^2.20.0"
-  pycodestyle = "^2.10.0"
-  pydocstyle = "^6.1.1"
-  pylint = "^2.15.6"
+  autopep8 = "2.0.0"
+  bandit = "1.7.4"
+  black = "22.10.0"
+  commitizen = "2.37.0" # Keep in sync with .pre-commit-config.yaml.
+  flake8 = "6.0.0"
+  flake8-bugbear = "22.10.27" # Keep in sync with .mega-linter.yaml.
+  isort = "5.10.1"
+  mccabe = "0.7.0" # Keep in sync with .mega-linter.yaml.
+  mypy = "0.982"
+  pre-commit = "2.20.0"
+  pycodestyle = "2.10.0"
+  pydocstyle = "6.1.1"
+  pylint = "2.15.6"
 
   [tool.pylint.messages_control]
   disable = "bad-whitespace, bad-continuation"


### PR DESCRIPTION
Using `^` allows the dependency version in use to exceed the version listed in `pyproject.toml`. When `poetry update` is run, `poetry.lock` is updated with the latest version of both direct and transitive dependencies, but `pyproject.toml` is not updated. The extra complexity of permitting `pyproject.toml` and `poetry.lock` to differ provides no value since we use Renovate to keep all of our dependencies up to date. Furthermore, using `^` can lead to direct dependency bumps being included in Renovate lock file maintenance rather than a dedicated pull request. Renovate subsequently opens pull requests that update `pyproject.toml` accordingly but with confusing commit messages based on the lock file stating the direct dependency was bumped from `x.y.z` to `x.y.z`. Pinning dependencies keeps `pyproject.toml` and `poetry.lock` in sync, and ensures that Renovate updates both in tandem in dedicated pull requests for direct dependencies.