### PR TITLE
chore(Poetry): Use `==` to specify exact versions

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -601,8 +601,8 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 
 [metadata]
 lock-version = "1.1"
-python-versions = "3.11.0"
-content-hash = "c68d5c485bfb20f54122e2a845dac5a28f3b5509091311098ff2c0027d91c2b3"
+python-versions = "==3.11.0"
+content-hash = "00b12bcb141f5ad67856e3832630e1127d27886555ef06825e126b05dc5821a9"
 
 [metadata.files]
 argcomplete = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,22 +36,22 @@ build-backend = "poetry.core.masonry.api"
 
   [tool.poetry.dependencies]
   # Keep in sync with .pre-commit-config.yaml and .tool-versions.
-  python = "3.11.0"
+  python = "==3.11.0"
 
   [tool.poetry.dev-dependencies]
-  autopep8 = "2.0.0"
-  bandit = "1.7.4"
-  black = "22.10.0"
-  commitizen = "2.37.0" # Keep in sync with .pre-commit-config.yaml.
-  flake8 = "6.0.0"
-  flake8-bugbear = "22.10.27" # Keep in sync with .mega-linter.yaml.
-  isort = "5.10.1"
-  mccabe = "0.7.0" # Keep in sync with .mega-linter.yaml.
-  mypy = "0.982"
-  pre-commit = "2.20.0"
-  pycodestyle = "2.10.0"
-  pydocstyle = "6.1.1"
-  pylint = "2.15.6"
+  autopep8 = "==2.0.0"
+  bandit = "==1.7.4"
+  black = "==22.10.0"
+  commitizen = "==2.37.0" # Keep in sync with .pre-commit-config.yaml.
+  flake8 = "==6.0.0"
+  flake8-bugbear = "==22.10.27" # Keep in sync with .mega-linter.yaml.
+  isort = "==5.10.1"
+  mccabe = "==0.7.0" # Keep in sync with .mega-linter.yaml.
+  mypy = "==0.982"
+  pre-commit = "==2.20.0"
+  pycodestyle = "==2.10.0"
+  pydocstyle = "==6.1.1"
+  pylint = "==2.15.6"
 
   [tool.pylint.messages_control]
   disable = "bad-whitespace, bad-continuation"


### PR DESCRIPTION
While Poetry appears to interpret the missing version constraints as exact version requirements, the official documentation requires use of a version constraint, such as `==`.