### PR TITLE
style(SlackNotification): Use `!r` conversion flag

### DIFF
--- a/src/slack_notification.py
+++ b/src/slack_notification.py
@@ -164,7 +164,7 @@ class SlackNotification(ABC):
         pattern = r"([^/]+)/([^/]+)"
         if not (match := fullmatch(pattern, self._repository)):
             raise ValueError(
-                f'Expected $GITHUB_REPOSITORY to match "{pattern}"; got: '
+                f"Expected $GITHUB_REPOSITORY to match {pattern!r}; got: "
                 f"{self._repository}"
             )
 


### PR DESCRIPTION
Prefer `!r`, which calls `repr()` rather than `str()`, to manually printing quotes around a string. `repr()` quotes strings and escapes any quotes they may contain automatically. This issue was detected by flake8-bugbear.