### PR TITLE
chore(mypy): Remove `show_error_codes` setting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ build-backend = "poetry.core.masonry.api"
   disallow_any_decorated = true
   disallow_any_unimported = true
   show_column_numbers = true
-  show_error_codes = true
   show_error_context = true
   strict = true
   pretty = true


### PR DESCRIPTION
mypy recently began showing error codes by default in v0.991.