### PR TITLE
chore(VSCode): Don't trim Git patch whitespace

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,3 +11,7 @@ insert_final_newline = true
 # Match the default pycodestyle style.
 [*.py]
 indent_size = 4
+
+[*.diff]
+# Preserve trailing whitespace so as not to break Git patch editing.
+trim_trailing_whitespace = false

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
+  "[diff]": {
+    "files.trimTrailingWhitespace": false
+  },
   "autopep8.importStrategy": "fromEnvironment",
   "black-formatter.importStrategy": "fromEnvironment",
   "editor.tabSize": 2,


### PR DESCRIPTION
VSCode and the EditorConfig VSCode extension are configured to trim trailing whitespace. This is generally desirable, but breaks Git patch editing, so disable whitespace trimming for `*.diff` files for both VSCode and EditorConfig.