### PR TITLE
chore(Renovate): Use fix prefix for Python bumps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>ScribeMD/.github#0.9.3"]
+  "extends": ["github>ScribeMD/.github#0.9.3"],
+  "packageRules": [
+    {
+      "matchDepNames": ["python"],
+      "semanticCommitType": "fix"
+    }
+  ]
 }


### PR DESCRIPTION
Cause Commitizen to release when the Python version changes, which is desirable because Python is a production dependency of the action.