### PR TITLE
chore(VSCode): Set Python to 4-space indentation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,9 @@
   "[diff]": {
     "files.trimTrailingWhitespace": false
   },
+  "[python]": {
+    "editor.tabSize": 4
+  },
   "autopep8.importStrategy": "fromEnvironment",
   "black-formatter.importStrategy": "fromEnvironment",
   "editor.tabSize": 2,


### PR DESCRIPTION
We already configure this behavior in EditorConfig, but mirror it in VSCode workspace settings for the benefit of those without the EditorConfig extension installed.