### PR TITLE
chore(VSCode): Include `poetry.lock` when searching

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,8 +25,5 @@
   "python.linting.mypyEnabled": true,
   "python.linting.pycodestyleEnabled": true,
   "python.linting.pydocstyleEnabled": true,
-  "python.terminal.activateEnvInCurrentTerminal": true,
-  "search.exclude": {
-    "poetry.lock": true
-  }
+  "python.terminal.activateEnvInCurrentTerminal": true
 }


### PR DESCRIPTION
Occasionally one may desire to search the Poetry lock file. Search results from the lock file may be ignored temporarily by collapsing them or permanently via the user setting `search.exclude`.