### PR TITLE
chore(Renovate): Use fix prefix for workflows

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,6 +4,10 @@
   "packageRules": [
     {
       "matchDepNames": ["python"],
+      "matchFiles": [
+        ".github/workflows/notify-assignee.yaml",
+        ".github/workflows/notify-reviewers.yaml"
+      ],
       "semanticCommitType": "fix"
     }
   ]


### PR DESCRIPTION
Cause Commitizen to release when a dependency found in the callable Notify Assignee or Notify Reviewers workflows changes.