### PR TITLE
chore(Renovate): Split fix commit prefix package rule

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,6 +4,9 @@
   "packageRules": [
     {
       "matchDepNames": ["python"],
+      "semanticCommitType": "fix"
+    },
+    {
       "matchFiles": [
         ".github/workflows/notify-assignee.yaml",
         ".github/workflows/notify-reviewers.yaml"


### PR DESCRIPTION
Renovate mixes `OR` and `AND` semantics in package rules, but in most cases, including `matchDepNames` and `matchFiles`, applies `AND` semantics. As we want bumps matching either rule to use the fix prefix, split the rule into two separate rules.