### PR TITLE
chore(Renovate): Use fix for `actions/checkout`

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,6 +12,10 @@
         ".github/workflows/notify-reviewers.yaml"
       ],
       "semanticCommitType": "fix"
+    },
+    {
+      "matchPackageNames": ["actions/checkout"],
+      "semanticCommitType": "fix"
     }
   ]
 }


### PR DESCRIPTION
We use `actions/checkout` in both called and local workflows. Renovate uses the commit prefix of the first occurrence of the dependency according to a sophisticated but deterministic ordering. It happens to consider the checkout in the local Test workflow to come first, so the existing `matchFiles` package rule is not applied to `actions/checkout`.