### PR TITLE
ci(autopep8): Run aggressively and recursively

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,10 @@ build-backend = "poetry.core.masonry.api"
 
 [tool]
   [tool.autopep8]
+  aggressive = 2
+  in-place = true
   max_line_length = 88
+  recursive = true
 
   [tool.black]
   target-version = ["py311"]


### PR DESCRIPTION
Increase aggression from the default of 0 to the maximum of 2, so that autopep8 fixes as many issues automatically as possible. Configure autopep8 to run recursively as a convenience when running it directly on the command line. The pre-commit hook already passes `--in-place`, but configure this setting as well for consistency between runs on the command line and pre-commit runs.