### PR TITLE
ci(isort): Remove isort config since we use Ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,9 +20,6 @@ build-backend = "poetry.core.masonry.api"
   ]
   major_version_zero = true
 
-  [tool.isort]
-  profile = "black"
-
   [tool.mypy]
   disallow_any_decorated = true
   disallow_any_unimported = true


### PR DESCRIPTION
isort is now configured via `[tool.ruff.isort]` rather than `[tool.isort]` since we recently started running isort via Ruff. Ruff sets `profile = "black"` by default though, so simply delete this section of our `pyproject.toml`.