### PR TITLE
ci(docformatter): Run in place and recursively

### DIFF
--- a/.dictionary.txt
+++ b/.dictionary.txt
@@ -1,3 +1,4 @@
 Laven
 requestee
 slackapi
+tomli

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,8 @@ repos:
     rev: v1.5.1
     hooks:
       - id: docformatter
-        args: [--wrap-summaries, "88", --wrap-descriptions, "88"]
+        additional_dependencies:
+          - tomli==2.0.1
 
   ## Markdown
   - repo: https://github.com/frnmst/md-toc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,12 @@ build-backend = "poetry.core.masonry.api"
   ]
   major_version_zero = true
 
+  [tool.docformatter]
+  in-place = true
+  recursive = true
+  wrap-descriptions = 88
+  wrap-summaries = 88
+
   [tool.mypy]
   disallow_any_decorated = true
   disallow_any_unimported = true


### PR DESCRIPTION
The pre-commit hook already passes `--in-place`, but we overrode this default argument, causing the hook to print diffs rather than modify files. Configure docformatter via `pyproject.toml` rather than pre-commit hook `args` to stop overriding this argument. Configure docformatter to run in place via `pyproject.toml` for consistency between command line and pre-commit runs. Also, configure docformatter to run recursively as a convenience when running it directly on the command line. Add tomli as an additional dependency of the pre-commit hook so it can parse `pyproject.toml`.