### PR TITLE
chore(Commitizen): Use Poetry version provider

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,11 +13,8 @@ build-backend = "poetry.core.masonry.api"
   target-version = ["py311"]
 
   [tool.commitizen]
-  version = "0.6.20"
-  version_files = [
-    "pyproject.toml:version",
-    "README.md:slack-templates@"
-  ]
+  version_provider = "poetry"
+  version_files = ["README.md:slack-templates@"]
   major_version_zero = true
 
   [tool.docformatter]


### PR DESCRIPTION
Commitizen recently introduced version providers in v3.0.0 so that the project version number no longer needs to be duplicated between the Commitizen and Poetry configs.