### PR TITLE
ci(docformatter): Use Black-compatibility option

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,10 +18,9 @@ build-backend = "poetry.core.masonry.api"
   major_version_zero = true
 
   [tool.docformatter]
+  black = true
   in-place = true
   recursive = true
-  wrap-descriptions = 88
-  wrap-summaries = 88
 
   [tool.mypy]
   disallow_any_decorated = true


### PR DESCRIPTION
docformatter recently added a single `black` option in v1.7.0 to enforce compatibility with Black. Remove the no longer needed `wrap-descriptions = 88` and `wrap-summaries = 88` settings that enforced Black's 88-character line length since `black = true` applies these settings.