### PR TITLE
fix(action): Skip notification when inputs blank

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -64,6 +64,7 @@ runs:
       shell: bash
       working-directory: "${{ github.action_path }}"
     - name: Send Slack notification.
+      if: inputs.bot-token != '' && inputs.channel-id != ''
       uses: slackapi/slack-github-action@v1.23.0
       with:
         channel-id: ${{ inputs.channel-id }}


### PR DESCRIPTION
Don't call slackapi/slack-github-action when no Slack bot token or channel ID is passed since both are necessary to issue a Slack notification. This occurs in pull requests from forks, such as those generated by Forking Renovate, because GitHub Actions does not allow forks access to secrets for security purposes.