### PR TITLE
fix(action): Read Python version from this repository

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -39,10 +39,10 @@ branding:
 runs:
   using: composite
   steps:
-    - name: Set up Python based on asdf Python version.
+    - name: Set up Python based on Python version in pyproject.toml.
       uses: actions/setup-python@v4.7.0
       with:
-        python-version-file: pyproject.toml
+        python-version-file: "${{ github.action_path }}/pyproject.toml"
     - name: Configure Slack notification.
       run: >
         python set_slack_message.py


### PR DESCRIPTION
When used as a called workflow, we were using the Python version in the calling repository's `pyproject.toml`. This can result in unpredictable versions of Python being used or a crash if no `pyproject.toml` is found. Read from `pyproject.toml` in this repository instead. Correct the name of the step to indicate that we read from `pyproject.toml`.