### PR TITLE
ci(MegaLinter): Correct GraphQL comment position

### DIFF
--- a/.mega-linter.yaml
+++ b/.mega-linter.yaml
@@ -1,10 +1,8 @@
 APPLY_FIXES: all
 CLEAR_REPORT_FOLDER: true
 DEFAULT_BRANCH: main
-# We use the .graphql extension for queries, not schemas, for the sake of syntax
-# highlighting.
 DISABLE_LINTERS:
-  - GRAPHQL_GRAPHQL_SCHEMA_LINTER
+  - GRAPHQL_GRAPHQL_SCHEMA_LINTER # We have .graphql queries, not schemas.
   - PYTHON_FLAKE8
   - PYTHON_ISORT
 FAIL_IF_MISSING_LINTER_IN_FLAVOR: true


### PR DESCRIPTION
The comment applies specifically to the graphql-schema-linter and not other disabled linters. Also, shorten the comment so it can be inlined.