### PR TITLE
ci(autopep8): Port from mirror to official repo

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
         args: *megalinter-args
 
   ## Python
-  - repo: https://github.com/pre-commit/mirrors-autopep8
+  - repo: https://github.com/hhatto/autopep8
     rev: v2.0.4
     hooks:
       - id: autopep8


### PR DESCRIPTION
The official autopep8 repository, `hhatto/autopep8`, recently added a pre-commit hook in v2.0.3, so it is no longer necessary to use a mirror.