### PR TITLE
ci(docformatter): Remove dependency on `tomli`

### DIFF
--- a/.dictionary.txt
+++ b/.dictionary.txt
@@ -1,4 +1,3 @@
 Laven
 requestee
 slackapi
-tomli

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,8 +39,6 @@ repos:
     rev: v1.7.5
     hooks:
       - id: docformatter
-        additional_dependencies:
-          - tomli==2.0.1
 
   ## Markdown
   - repo: https://github.com/frnmst/md-toc


### PR DESCRIPTION
In v1.7.1, `docformatter` recently began using `tomllib` to parse `pyproject.toml` in Python 3.11+, so it no longer requires `tomli`.