### PR TITLE
ci(mypy): Show line and column ends in errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,8 @@ build-backend = "poetry.core.masonry.api"
   [tool.mypy]
   disallow_any_decorated = true
   disallow_any_unimported = true
-  show_column_numbers = true
   show_error_context = true
+  show_error_end = true
   strict = true
   pretty = true
   warn_unreachable = true


### PR DESCRIPTION
mypy recently added support for displaying the line and column ranges of errors in v0.981. Enable this setting via `show_error_end = true`. This implies `show_column_numbers = true`, so remove the latter setting now that it's redundant.