### PR TITLE
chore(VSCode): Remove `python.formatting.provider`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,7 +16,6 @@
   "pylint.importStrategy": "fromEnvironment",
   "python.analysis.typeCheckingMode": "strict",
   "python.defaultInterpreterPath": "./.venv/bin/python",
-  "python.formatting.provider": "black",
   "python.linting.banditEnabled": true,
   "python.linting.enabled": true,
   "python.linting.mypyEnabled": true,


### PR DESCRIPTION
The Python VSCode extension is being split into separate extensions. We already use the Black extension for formatting instead of the Python extension, so remove a soon-to-be-deprecated setting that controls which formatter the Python extension uses.