### PR TITLE
chore(VSCode): Recommend Mypy Type Checker

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -9,6 +9,7 @@
     "ms-azuretools.vscode-docker",
     "ms-python.autopep8",
     "ms-python.black-formatter",
+    "ms-python.mypy-type-checker",
     "ms-python.pylint",
     "ms-python.python",
     "ms-python.vscode-pylance",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,12 +13,12 @@
   "files.insertFinalNewline": true,
   "files.trimTrailingWhitespace": true,
   "git.branchProtection": ["main"],
+  "mypy-type-checker.importStrategy": "fromEnvironment",
   "pylint.importStrategy": "fromEnvironment",
   "python.analysis.typeCheckingMode": "strict",
   "python.defaultInterpreterPath": "./.venv/bin/python",
   "python.linting.banditEnabled": true,
   "python.linting.enabled": true,
-  "python.linting.mypyEnabled": true,
   "python.linting.pycodestyleEnabled": true,
   "python.terminal.activateEnvInCurrentTerminal": true
 }


### PR DESCRIPTION
The Python extension is being split into separate extensions, so configure the Python extension to stop running mypy. Configure the Mypy Type Checker to use the version of mypy we pin via Poetry.