### PR TITLE
chore(Poetry): Group dev deps with updated syntax

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1089,4 +1089,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "==3.11.5"
-content-hash = "59d8deb33a04c523a4dd77fb79129d5281863412f0afba2232ea11b4ede6265b"
+content-hash = "3f5a59fec0fda631b86c6cf7d94f6239264a53bc478d69d5c85b705c54251703"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ build-backend = "poetry.core.masonry.api"
   # Keep in sync with .pre-commit-config.yaml and .tool-versions.
   python = "==3.11.5"
 
-  [tool.poetry.dev-dependencies]
+  [tool.poetry.group.dev.dependencies]
   autopep8 = "==2.0.4"
   bandit = "==1.7.5"
   black = "==23.7.0"


### PR DESCRIPTION
Previously, development dependencies were grouped under `[tool.poetry.dev-dependencies]` in `pyproject.toml`. This syntax will soon be deprecated. Group development dependencies under `[tool.poetry.group.dev.dependencies]`, the updated syntax as of Poetry v1.2.0.