### PR TITLE
ci(mypy): Link to documentation from errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ build-backend = "poetry.core.masonry.api"
   [tool.mypy]
   disallow_any_decorated = true
   disallow_any_unimported = true
+  show_error_code_links = true
   show_error_context = true
   show_error_end = true
   strict = true


### PR DESCRIPTION
In v1.5.0, mypy recently added support for printing links to its documentation once per error code, so enable it.