### PR TITLE
ci(workflow): Hasten checkout with blobless clones

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@v4.1.0
         with:
           fetch-depth: 0
+          filter: blob:none
       - name: Run pre-commit hooks.
         uses: ScribeMD/pre-commit-action@0.9.107
       - name: Send Slack notification with job status.


### PR DESCRIPTION
In v4.1.0, actions/checkout recently introduced support for Git's partial clones. Partial clones are smaller than full clones (`fetch-depth: 0`), because they don't clone historical blobs and/or trees. Partial clones do clone all historical commits and tags though, so they are larger than depth 1 shallow clones, the default when `fetch-depth` isn't specified. In partial clones, unlike shallow clones, Git operations will typically fetch data that isn't available locally as needed. Hence, prefer blobless clones, the partial clones that give the best performance overall, to full clones, but continue using shallow clones when historical commits and tags aren't needed (e.g., by Commitizen).