### PR TITLE
docs(README): Correct the spelling of "requester"

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ are all currently supported templates:
     - direct push of branch: \<workflow> **\<result>** for push of \<sha> to
       \<branch> on \<repository> by \<username>.
 - `"reviewers"`:
-  - `requestor != requestee`: \<requestor> requests review from **\<reviewers>**
+  - `requester != requestee`: \<requester> requests review from **\<reviewers>**
     of \<PR #> from \<branch> on \<repository>.
-  - `requestor == requestee`: \<username> self-requests review of \<PR #> from
+  - `requester == requestee`: \<username> self-requests review of \<PR #> from
     \<branch> on \<repository>.
 - `"assignee"`:
   - `assignor != assignee`: \<assignor> assigned **\<assignee>** \<PR #> from


### PR DESCRIPTION
We had misspelled "requester" as "requestor."