### PR TITLE
docs(README): Use code span, not quotes, for code

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ because merges will be indistinguishable from direct pushes.
 
 ### Summarize the results of an entire workflow
 
-- Create a new job at the end of the workflow that depends on (a.k.a., "needs")
+- Create a new job at the end of the workflow that depends on (a.k.a., `needs`)
   all other jobs but always runs.
 - Pass `"${{ join(needs.*.result, ' ') }}"` as the `results`.
 


### PR DESCRIPTION
`needs` is part of the workflow syntax for GitHub Actions.