### PR TITLE
chore(pyproject): Target Python 3.12 in Black/Ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "poetry.core.masonry.api"
   recursive = true
 
   [tool.black]
-  target-version = ["py311"]
+  target-version = ["py312"]
 
   [tool.commitizen]
   version_provider = "poetry"
@@ -76,7 +76,7 @@ build-backend = "poetry.core.masonry.api"
     "S",
     "T20"
   ]
-  target-version = "py311"
+  target-version = "py312"
 
   [tool.ruff.flake8-annotations]
   mypy-init-return = true


### PR DESCRIPTION
We are on Python 3.12.0, so configure Black and Ruff to reflect this rather than target Python 3.11.