### PR TITLE
ci(Pylint): Stop disabling removed rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,6 @@ build-backend = "poetry.core.masonry.api"
   ruff = "==0.1.5"
 
   [tool.pylint.messages_control]
-  disable = "bad-whitespace, bad-continuation"
   max-line-length = 88
 
   [tool.ruff]


### PR DESCRIPTION
We had disabled `bad-continuation` and `bad-whitespace` for compatibility with Black, but these rules were removed in Pylint 2.6.