### PR TITLE
chore(Renovate): Migrate to `matchFileNames`

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,7 +7,7 @@
       "semanticCommitType": "fix"
     },
     {
-      "matchFiles": [
+      "matchFileNames": [
         ".github/workflows/notify-assignee.yaml",
         ".github/workflows/notify-reviewers.yaml"
       ],


### PR DESCRIPTION
`matchFiles` was replaced with `matchFileNames` in Renovate v36.0.0.